### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -9,7 +9,7 @@ permalink: /guides/guide-codewind/
 :page-layout: guide
 :page-duration: 30
 :page-releasedate: TBD
-:page-guide-category: developer tools
+:page-guide-category: collections
 :page-essential: true
 :page-essential-order: 1
 :page-description: Take advantage of Codewind's tools to help build high quality cloud native applications regardless of which IDE or language you use. 
@@ -17,32 +17,36 @@ permalink: /guides/guide-codewind/
 :page-tags: ['kabanero', 'appsody', 'codewind', 'microservice']
 :page-permalink: /guides/{projectid}
 :repo-description: TBD
-= Getting Started with Codewind in Kabanero
+= Getting Started with Codewind and Kabanero
 :toc:
 
 == Objectives
 
 *Learning objectives*
 
-You can either:
+In this guide you will learn how to develop a simple microservice with your chosen IDE, using Eclipse Codewind, an open source project, which provides IDE extensions for popular IDEs (VSCode and Eclipse IDE).  Eclipse Codewind provides the ability to create new projects based on Kabanero Collections that include application stacks customized to meet your company policies and consistently deploy apps and microservices at scale.
 
-* Install Codewind and begin <<#developing-with-vs-code, developing with VS Code>> or <<#developing-with-eclipse, developing with Eclipse>>. 
-* Develop a simple microservice with your chosen IDE. 
+== Overview 
 
-== Kabanero Overview 
+Kabanero's developer experience for IDEs is provided by Elcipse Codewind.  For more information on how Kabanero and its components work, visist https://kabanero.io/guides/overview/#architecture[Kabanero's Architecture and Development Workflows].
 
-Before working with Codewind, understand that Codewind works within Kabanero, an open source project in a microservices-based framework.
-For more information on how Kabanero and its components work, visist https://kabanero.io/guides/overview/#architecture[Kabanero's Architecture and Development Workflows].
+Kabanero installs on OKD (The Origin Community Distribution of Kubernetes) or OpenShift and integrates a modern DevOps toolchain and Kabanero Collections which enable developers to use runtimes and frameworks in pre-built container images called 'Application stacks'.  
 
-To deploy your applications onto OpenShift, you need to build and work with Kabanero Collections. If you plan to deploy any applications onto OpenShift complete the guide, https://kabanero.io/guides/working-with-collections/[Working with Kabanero Collections]. 
+Eclipse Codewind provides the ability to create application projects for these 'Application Stacks' that your company has built, enabling developers to focus on their code and not infrastructure and Kubernetes.  Application deployments to Kubernetes occur via pipelines when developers commit their local code to the correct Git repos Kabanero is managing via webhooks.    
+
+Eclipse Codewind provides the ability to create projects based on a variety of different template types.  These include IBM Cloud starters, Odo, and Appsody templates.  When used with Kabanero you will only use Appsody templates for the Collections your company has enabled.  Today there are collections for: Eclipse MicroProfile/Java EE, Springboot, Node.js, Node.js with Express, Node.js with Loopback.
 
 == Developing a simple microservice
 
+Select the guide section based on your IDE of choice.
+
+<<#developing-with-vs-code, developing with VS Code>> 
+
+<<#developing-with-eclipse, developing with Eclipse>>
+
 === *Developing with VS Code*
 
-Why Visual Studio Code (VS Code)? You can use Codewind for VS Code to develop and debug your containerized projects from within VS Code.
-
-Codewind for VS Code supports development of Microprofile/Java EE, Java Lagom, Spring, Node.js, Go,Python, Swift, and Appsody containerized projects.
+If you use Visual Studio Code (VS Code), you can use Codewind for VS Code to develop and debug your containerized projects from within VS Code using the workflow you already use today.
 
 *Prerequisite*
 
@@ -171,14 +175,14 @@ You could also try a few of the sample calculator functions:
 
 You have created a simple microservice using the VS Code IDE. For further learning:
 
-* Visit this https://www.eclipse.org/codewind/mdt-vsc-tutorial.html[tutorial on Codewind for VS Code].
+* Try https://www.kabanero.io/guides[additional Kabanero guides] available for each Collection: Eclipse MicroProfile, Springboot, Node.js.
+
+* Visit https://www.eclipse.org/codewind/ for more details on using Codewind.
 * Review https://www.eclipse.org/codewind/mdt-vsc-commands-project.html[project commands for Codewind for VS Code].
 
 === *Developing with Eclipse*
 
-Why Eclipse? You can use Codewind for Eclipse to develop and debug your containerized projects from within Eclipse.
-
-Codewind for Eclipse supports development of Microprofile/Java EE, Java Lagom, Spring, Node.js, Go,Python, Swift, and Appsody containerized projects. 
+If you are an Eclipse IDE user, you can use Codewind for Eclipse to develop and debug your containerized projects from within a local Eclipse IDE.
 
 *Prerequisite* 
 
@@ -311,6 +315,10 @@ You could also try a few of the sample calculator functions:
 *Nice work! Where to next?*
 
 You have completed a simple microservice using the Eclipse IDE. For further learning: 
+
+* Try https://www.kabanero.io/guides[additional Kabanero guides] available for each Collection: Eclipse MicroProfile, Springboot, Node.js.
+
+* Visit https://www.eclipse.org/codewind/ for more details on using Codewind.
 
 * Review https://www.eclipse.org/codewind/mdteclipsemanagingprojects.html[managing Codewind projects for Eclipse]. 
 


### PR DESCRIPTION
Made a bunch of edits to the introduction sections and limited details to those specific to what we provide in Kabanero vs everything that Codewind may enable outside of the scope of Kabanero.  

The issue that remains is that you are not showing how to configure Codewind to use Kabanero Collections in a CollectionHub.  Using default appsodyhub is not in context of use with Kabanero and will result in significant issues in the context of Kabanero.