### PR TITLE
Add units to digit for the guide duration

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 permalink: /guides/guide-codewind/
 ---
 :page-layout: guide
-:page-duration: 30
+:page-duration: 30 minutes
 :page-releasedate: 2019-11-22
 :page-guide-category: collections
 :page-description: Take advantage of Codewind's tools to help build high quality cloud native applications regardless of which IDE or language you use. 


### PR DESCRIPTION
Duration for this guide displays `30` on `https://kabanero.io/guides/` where it should add the unit to read `30 minutes`.

![Screen Shot 2019-12-09 at 2 26 22 PM](https://user-images.githubusercontent.com/37549026/70465872-ebfb9380-1a8f-11ea-8394-4137863a5922.png)
